### PR TITLE
fix two links in setup

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,5 +10,5 @@ use the OpenRefine software to work with data files.
 > ## Prerequisites
 >
 > You will need to install [Firefox](https://www.mozilla.org/en-US/firefox/new/)
-> and [Open Refine 2.6](http://openrefine.org/download.html) to complete this lesson.
+> and [OpenRefine](http://openrefine.org/download.html) to complete this lesson.
 {: .prereq}

--- a/setup.md
+++ b/setup.md
@@ -32,7 +32,7 @@ To run Refine:
 * On Linux: Navigate to the folder where you’ve installed OpenRefine in a terminal window and type ‘./refine’
 * On Mac: Navigate to where you installed OpenRefine and click the OpenRefine icon
 
-The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333.If this doesn't happen automatically you can open a web browser and type in this address.
+The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333. If this doesn't happen automatically you can open a web browser and type in this address.
 
 ### Getting Help
 

--- a/setup.md
+++ b/setup.md
@@ -4,9 +4,11 @@ title: Setup
 permalink: /setup/
 ---
 ## Getting ready
+
 You need to download and install OpenRefine and download a data file to follow this lesson.
 
 ### Downloading OpenRefine
+
 You can download OpenRefine from http://openrefine.org/download.html. There are two versions you can use for this lesson:
 
 * Google Refine 2.5
@@ -17,11 +19,12 @@ Generally OpenRefine 2.6 is recommended.
 There are versions for Windows, Mac OS X and Linux.
 
 ### Installing and Running OpenRefine
+
 When you download OpenRefine for Windows or Linux from the address above, you are downloading a zip file. To install OpenRefine you simply unzip the downloaded file wherever you want to install the program. This can be to a personal directory or to an applications or software directory - OpenRefine should run wherever you put the unzipped folder. The location has to be a "local" drive as problems have been reported trying to run OpenRefine from a Network drive.
 
-If you are downloading OpenRefine for Mac, you a re downloading a ‘dmg’ (disk image) file which you can open, and then drag the OpenRefine application to an appropriate folder on you computer.
+If you are downloading OpenRefine for Mac, you are downloading a 'dmg' (disk image) file which you can open, and then drag the OpenRefine application to an appropriate folder on you computer.
 
-OpenRefine is a java application, and you need to have a ‘java runtime environment’ (JRE) installed on your computer to run OpenRefine. If you don’t already have one installed then you can download and install from http://java.com by going to the site and clicking ‘Free Java Download’.
+OpenRefine is a Java application, and you need to have a 'Java Runtime Environment' (JRE) installed on your computer to run OpenRefine. If you don’t already have one installed then you can download and install from [http://java.com](http://java.com) by going to the site and clicking "Free Java Download".
 
 To run Refine:
 
@@ -29,9 +32,10 @@ To run Refine:
 * On Linux: Navigate to the folder where you’ve installed OpenRefine in a terminal window and type ‘./refine’
 * On Mac: Navigate to where you installed OpenRefine and click the OpenRefine icon
 
-The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333.If this doesn’t happen automatically you can open a web browser and type in this address.
+The interface to OpenRefine is accessed via a web browser. When you run Refine normally this should open a window in your default web browser pointing at the address http://127.0.0.1:3333.If this doesn't happen automatically you can open a web browser and type in this address.
 
 ### Getting Help
+
 If you encounter problems installing or running OpenRefine, a good source of support is [the OpenRefine mailing list and forum](https://groups.google.com/forum/?fromgroups#!forum/openrefine)
 
 If you are installing OpenRefine on Windows, you may want to check the thread on [Installing OpenRefine on Windows 7](https://groups.google.com/forum/?fromgroups#!searchin/openrefine/64-bit%7Csort:date/openrefine/vUzqJqJ-sAA/Tb2Om9wvaqgJ)
@@ -44,10 +48,11 @@ There are also general and specialist tutorials about using OpenRefine available
 * [Identifying potential headings for Authority work using III Sierra, MS Excel and OpenRefine](http://epublications.marquette.edu/lib_fac/81/)
 * [Free your metadata website](http://freeyourmetadata.org)
 * [Data Munging Tools in Preparation for RDF: Catmandu and LODRefine by Christina Harlow](http://journal.code4lib.org/articles/11013)
-* [Walkthrough of Geonames Recon Service by Christina Harlow](http://christinaharlow.com/walkthrough-of-geonames-recon-service/)
+* [Walkthrough of Geonames Recon Service by Christina Harlow](http://christinaharlow.com/walkthrough-of-geonames-recon-service)
 * [OpenRefine News (monthly round up of new blog posts, tutorials and other information)](http://openrefine.org/blog.html)
 
 ### Downloading the data
+
 You need to download [doaj-article-sample.csv](https://github.com/data-lessons/library-openrefine/raw/gh-pages/data/doaj-article-sample.csv), which is a csv file. Make a note of the location you save the file.
 
 [template]: {{ site.workshop_repo }}


### PR DESCRIPTION
This small PR fixes a broken link in the setup and adds link for java download.
Plus a few minor edits: capitalizes Java, writes OpenRefine with no space, added space in markdown between header and paragraph for ease of reading.