### PR TITLE
adding 02-importing-data formating of exercise and text

### DIFF
--- a/_episodes/02-importing-data.md
+++ b/_episodes/02-importing-data.md
@@ -15,32 +15,36 @@ keypoints:
 
 If you haven't already, at this point download [doaj-article-sample.csv](https://github.com/data-lessons/library-openrefine/raw/gh-pages/data/doaj-article-sample.csv), which is a csv file. Make a note of the location you save the file.
 
-### Exercise 1: Create your first Open Refine project (using provided data)
-There are several options for getting your data set into OpenRefine. You can upload or import files in a variety of formats including:
+>## What kinds of data files can I import?
+>There are several options for getting your data set into OpenRefine. You can upload or import files in a variety of formats including:
+>
+>* TSV (tab-separated values)
+>* CSV (comma-separated values)
+>* Excel
+>* JSON (javascript object notation)
+>* XML
+>* Google Spreadsheet
+{: .callout}
 
-* TSV (tab-separated values)
-* CSV (comma-separated values)
-* Excel
-* JSON (javascript object notation)
-* XML
-* Google Spreadsheet
-
-To import the data for the exercises below, run OpenRefine. *NOTE: If Open Refine does not open in a browser window, open your browser and type the address http://127.0.0.1:3333/ to take you to the Open Refine interface.*
-
-* Locate the file which you have downloaded called 'doaj-article-sample.csv'
-* Click 'Next'
-
-The next screen gives you some options to ensure that the data gets imported into OpenRefine correctly. The options vary depending on the type of data you are importing.
-
-In this case you need to:
-
-* Set the 'Character encoding' to 'UTF-8'
-* Ensure the first row is used to create the column headings
-* Make sure OpenRefine doesn't try to automatically detect numbers and dates
-
-Once you are happy click 'Create Project >>'
-
-This will create the project and open it for you. Projects are saved as you work on them, there is no need to save copies as you go along.
+>## Exercise 1: Create your first Open Refine project (using provided data)
+>
+>To import the data for the exercises below, run OpenRefine. *NOTE: If Open Refine does not open in a browser window, open your browser and type the address <http://127.0.0.1:3333/> to take you to the Open Refine interface.*
+>
+>1. Locate the file which you have downloaded called `doaj-article-sample.csv`
+>2. Click 'Next'
+>   
+>    The next screen gives you some options to ensure that the data gets imported into OpenRefine correctly. The options vary depending on the type of data you are importing.
+>    
+>    In this case you need to:
+>    
+>1. Set the 'Character encoding' to `UTF-8`
+>2. Ensure the first row is used to create the column headings
+>3. Make sure OpenRefine doesn't try to automatically detect numbers and dates
+>
+>    Once you are happy click `Create Project >>`
+>
+>    This will create the project and open it for you. Projects are saved as you work on them, there is no need to save copies as you go along.
+{: .challenge}
 
 To open an existing project in OpenRefine you can click 'Open Project' from the main OpenRefine screen (in the left hand menu). When you click this, you will see a list of the existing projects and can click on a project's name to open it.
 


### PR DESCRIPTION
@pitviper6 and @ostephens: I'm teaching this material next week in Pittsburgh and am preparing, but thought I'd take the opportunity to wrap the exercises and callouts in the [SWC style template blockquotes](https://swcarpentry.github.io/lesson-example/04-formatting/#special-blockquotes). Let me know if this is not what you want, otherwise I can do it for each episode and send you PRs. You can see what it looks rendered here: http://www.tim-dennis.com/library-openrefine/02-importing-data/