### PR TITLE
Basic Open Refine 1 - exercise #5

### DIFF
--- a/_episodes/03-basic-functions-I.md
+++ b/_episodes/03-basic-functions-I.md
@@ -116,7 +116,7 @@ OpenRefine has two modes of viewing data 'Rows' and 'Records'. So far we've been
 How this works can be seen in the next exercise...
 
 >## Exercise 5: Split author names into separate cells
->If you look at the Author column you should be able to see that there are multiple names in each cell separated by the pipe symbol "|". >To work with the author names effectively we need to split them into separate cells:
+>If you look at the Author column you should be able to see that there are multiple names in each cell separated by the pipe symbol "|". To work with the author names effectively we need to split them into separate cells:
 >
 >* Click the dropdown menu at the top of the Author column
 >* Choose 'Edit cells->Split multi-valued cells'


### PR DESCRIPTION
Under exercise #5: removed extraneous ">" before sentence "To work with the author names effectively we need to split them into separate cells:"

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
