### PR TITLE
Should be General not Google

### DIFF
--- a/_episodes/07-using-transformations.md
+++ b/_episodes/07-using-transformations.md
@@ -32,7 +32,7 @@ However, sometimes there will be changes you want to make to the data that canno
 * Standardising the format of data in a column without changing the values (e.g. removing punctuation or standardising a date format)
 * Extracting a particular type of data from a longer text string (e.g. finding ISBNs in a bibliographic citation)
 
-To support this type of activity OpenRefine supports 'Transformations' which are ways of manipulating data in columns. Transformations are normally written in a special language called 'GREL' (Google Refine Expression Language). To some extent GREL expressions are similar to Excel Formula, although they tend to focus on text manipulations rather than numeric functions.
+To support this type of activity OpenRefine supports 'Transformations' which are ways of manipulating data in columns. Transformations are normally written in a special language called 'GREL' (General Refine Expression Language). To some extent GREL expressions are similar to Excel Formula, although they tend to focus on text manipulations rather than numeric functions.
 
 Full documentation for the GREL is available at [https://github.com/OpenRefine/OpenRefine/wiki/General-Refine-Expression-Language](https://github.com/OpenRefine/OpenRefine/wiki/General-Refine-Expression-Language). This tutorial covers only a small subset of the commands available.
 


### PR DESCRIPTION
It looks like someone accidentally used the older version of what GREL stood for when it was GoogleRefine. The Google should be changed to General here.

