### PR TITLE
Should Be Subjects cells for consistency

### DIFF
--- a/_episodes/03-working-with-data.md
+++ b/_episodes/03-working-with-data.md
@@ -115,7 +115,7 @@ Splitting on a comma will not work with Authors because the names may include co
 
 >## Splitting Subjects into separate cells
 >
->1. What separator character is used in the Subject headings cells?
+>1. What separator character is used in the Subjects cells?
 >2. How would you split these subject words into individual cells?
 > 
 > > ## Solution


### PR DESCRIPTION
The column is labeled Subjects, so this should be used instead of Subject headings cells. This way there will be no confusion with what students are looking at, and Subjects is consistent with how this column is referred to in the rest of the lesson.

