### PR TITLE
Adding Checklist formatting to step-by-step directions

### DIFF
--- a/_episodes/02-importing-data.md
+++ b/_episodes/02-importing-data.md
@@ -13,8 +13,6 @@ keypoints:
 
 ## Importing data
 
-Please see Downloading Data on the Setup page http://data-lessons.github.io/library-openrefine/setup/
-
 >## What kinds of data files can I import?
 >There are several options for getting your data set into OpenRefine. You can upload or import files in a variety of formats including:
 >
@@ -30,24 +28,19 @@ Please see Downloading Data on the Setup page http://data-lessons.github.io/libr
 >
 > To import the data for the exercises below, run OpenRefine. *NOTE: If OpenRefine does not open in a browser window, open your browser and type the address <http://127.0.0.1:3333/> to take you to the OpenRefine interface.*
 >
->1. Locate the file which you have downloaded called `doaj-article-sample.csv`
->2. Click 'Next'
+>1. Once OpenRefine is launched in your browser, click `Create Project` from the left hand menu and select `Get data from This Computer`
+>2. Click `Choose Files` and locate the file which you have downloaded called `doaj-article-sample.csv` *(if you haven't downloaded it yet, please see 'Downloading the data' in the Setup page [http://data-lessons.github.io/library-openrefine/setup/](http://data-lessons.github.io/library-openrefine/setup/))*
+>3. Click `Next >>` - the next screen (see below) gives you options to ensure the data is imported into OpenRefine correctly. The options vary depending on the type of data you are importing.
+>4. Click in the `Character encoding` box and set it to `UTF-8`
+>5. Ensure the first row is used to create the column headings by checking the box `Parse next 1 line(s) as column headers`
+>6. Make sure the `Parse cell text into numbers, dates, ...` box is not checked, so OpenRefine doesn't try to automatically detect numbers
+>7. Once you are happy click the `Create Project >>` button at the top right of the screen. This will create the project and open it for you. Projects are saved as you work on them, there is no need to save copies as you go along.
 >   
 > ![Create project screen capture](../assets/img/openrefine_ui.png)
-> The next screen gives you some options to ensure that the data gets imported into OpenRefine correctly. The options vary depending on the type of data you are importing.
->    
->    In this case you need to:
->    
->1. Click in the 'Character encoding' box to set it to `UTF-8`
->2. Ensure the first row is used to create the column headings
->3. Make sure the ‘Parse cell text into numbers, dates‘ box is not checked, so OpenRefine doesn't try to automatically detect numbers
 >
->    Once you are happy click the`Create Project >>`button at the top right of the screen
->
->    This will create the project and open it for you. Projects are saved as you work on them, there is no need to save copies as you go along.
-{: .challenge}
+{: .checklist}
 
-To open an existing project in OpenRefine you can click 'Open Project' from the main OpenRefine screen (in the left hand menu). When you click this, you will see a list of the existing projects and can click on a project's name to open it.
+To open an existing project in OpenRefine you can click `Open Project` from the main OpenRefine screen (in the left hand menu). When you click this, you will see a list of the existing projects and can click on a project's name to open it.
 
 ### Going Further
 * Look at the other options on the Import screen - try changing some of these options and see how that changes the Preview and how the data appears after import.


### PR DESCRIPTION
Adding 'checklist' formatting to the step-by-step directions that
learners are required to follow in this episode. This requires changing
the callout code from ’challenge’ to ‘checklist’, and
rearranging/editing instructions to make the checklist match the exact
process in OpenRefine’s user interface (e.g. buttons). The first
sentence in the episode has moved to step 2. Please see
https://github.com/data-lessons/library-openrefine/issues/146 for
details about formatting changes.